### PR TITLE
DOC: fixing link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ remotes::install_github("ropenscilabs/tic")
 When using `tic` it is helpful to be somewhat familiar with the concept of [continuous integration](https://ropenscilabs/tic/articles/tic.html#prerequisites) (CI).  
 By calling `usethis::use_ci()` a production ready setup for the respective R project is initialized.  
 This function will create a CI setup for both providers Travis and Appveyor.  
-For more information see the [Getting started](https://ropenscilabs/tic/articles/tic.html#setup) vignette.
+For more information see the [Getting started](https://ropenscilabs.github.io/tic/articles/tic.html#setup) vignette.
 
 ## Further reading
 


### PR DESCRIPTION
Fixing a link on the README as it's linked from https://ropensci.github.io/dev_guide/ci.html#make-more-of-your-ci-builds-tic