### PR TITLE
Update step_rcmdcheck() to rcmdcheck v1.3.2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# tic 0.2.13.9011
+
+## step_rcmdcheck()
+
+- replace `warnings_are_errors` and `notes_are_errors` with `error_on`
+- add args `timeout` and `repos`
+- call `rcmdcheck()` internally with `error_on = "never"` so that we can trigger the message on found warnings and notes
+- remote outdated doc about `step_rcmdcheck()` using a dedicated lib for the check
+
 # tic 0.2.13.9010
 
 - No longer using a separate library for package checks, because it causes a lot of problems with various steps which are not aware of this (#86, #88).

--- a/R/dsl.R
+++ b/R/dsl.R
@@ -96,10 +96,9 @@ add_code_step <- function(stage, call = NULL, prepare_call = NULL) {
 #' @rdname DSL
 #' @export
 #' @importFrom magrittr %>%
-add_package_checks <- function(warnings_are_errors = TRUE,
-                               notes_are_errors = FALSE,
-                               args = c("--no-manual", "--as-cran"),
-                               build_args = "--force") {
+add_package_checks <- function(args = c("--no-manual", "--as-cran"),
+                               build_args = "--force", error_on = "warning",
+                               repos = getOption("repos"), timeout = Inf) {
   #' @description
   #' 1. A [step_rcmdcheck()] in the `"script"` stage, using the
   #'    `warnings_are_errors`, `notes_are_errors`, `args`, and
@@ -107,10 +106,11 @@ add_package_checks <- function(warnings_are_errors = TRUE,
   get_stage("script") %>%
     add_step(
       step_rcmdcheck(
-        warnings_are_errors = warnings_are_errors,
-        notes_are_errors = notes_are_errors,
         args = args,
-        build_args = build_args
+        build_args = build_args,
+        error_on = error_on,
+        repos = repos,
+        timeout = timeout
       )
     )
 

--- a/R/steps-rcmdcheck.R
+++ b/R/steps-rcmdcheck.R
@@ -76,18 +76,11 @@ RCMDcheck <- R6Class(
 #' via [remotes::install_deps()] with `dependencies = TRUE`,
 #' and updating all packages.
 #'
-#' This step uses a dedicated library,
-#' a subdirectory `tic-pkg` of the current user library
-#' (the first element of [.libPaths()]),
-#' for the checks.
-#' This is done to minimize conflicts between dependent packages
-#' and packages that are required for running the various steps.
-#'
 #' @param args `[character]`\cr
-#'   Passed to `[rcmdcheck::rcmdcheck()]`, default:
+#'   Passed to `rcmdcheck::rcmdcheck()`, default:
 #'   `c("--no-manual", "--as-cran")`.
 #' @param build_args `[character]`\cr
-#'   Passed to `[rcmdcheck::rcmdcheck()]`, default:
+#'   Passed to `rcmdcheck::rcmdcheck()`, default:
 #'   `"--force"`.
 #' @param error_on `[character]`\cr
 #'   Whether to throw an error on R CMD check failures. Note that the check is
@@ -97,10 +90,10 @@ RCMDcheck <- R6Class(
 #'   generate errors as well. If "note", then any check failure generated an
 #'   error.
 #' @param repos `[character]`\cr
-#'   Passed to `[rcmdcheck::rcmdcheck()]`, default:
+#'   Passed to `rcmdcheck::rcmdcheck()`, default:
 #'   `getOption("repos")`.
 #' @param timeout `[numeric]`\cr
-#'   Passed to `[rcmdcheck::rcmdcheck()]`, default:
+#'   Passed to `rcmdcheck::rcmdcheck()`, default:
 #'   `Inf`.
 #' @export
 step_rcmdcheck <- function(args = c("--no-manual", "--as-cran"),

--- a/man/DSL.Rd
+++ b/man/DSL.Rd
@@ -14,9 +14,9 @@ add_step(stage, step)
 
 add_code_step(stage, call = NULL, prepare_call = NULL)
 
-add_package_checks(warnings_are_errors = TRUE,
-  notes_are_errors = FALSE, args = c("--no-manual", "--as-cran"),
-  build_args = "--force")
+add_package_checks(args = c("--no-manual", "--as-cran"),
+  build_args = "--force", error_on = "warning",
+  repos = getOption("repos"), timeout = Inf)
 }
 \arguments{
 \item{name}{\code{[string]}\cr
@@ -36,19 +36,29 @@ The default is useful if you only pass \code{prepare_call}.}
 \item{prepare_call}{\code{[call]}\cr
 An optional arbitrary expression executed during preparation.}
 
-\item{warnings_are_errors}{\code{[flag]}\cr
-Should warnings be treated as errors? Default: \code{TRUE}.}
-
-\item{notes_are_errors}{\code{[flag]}\cr
-Should notes be treated as errors? Default: \code{FALSE}.}
-
 \item{args}{\code{[character]}\cr
-Passed to \code{[rcmdcheck::rcmdcheck()]}, default:
+Passed to \code{rcmdcheck::rcmdcheck()}, default:
 \code{c("--no-manual", "--as-cran")}.}
 
 \item{build_args}{\code{[character]}\cr
 Passed to \code{[rcmdcheck::rcmdcheck()]}, default:
 \code{"--force"}.}
+
+\item{error_on}{\code{[character]}\cr
+Whether to throw an error on R CMD check failures. Note that the check is
+always completed (unless a timeout happens), and the error is only thrown
+after completion. If "never", then no errors are thrown. If "error", then
+only ERROR failures generate errors. If "warning", then WARNING failures
+generate errors as well. If "note", then any check failure generated an
+error.}
+
+\item{repos}{\code{[character]}\cr
+Passed to \code{[rcmdcheck::rcmdcheck()]}, default:
+\code{getOption("repos")}.}
+
+\item{timeout}{\code{[numeric]}\cr
+Passed to \code{[rcmdcheck::rcmdcheck()]}, default:
+\code{Inf}.}
 }
 \description{
 Functions to define stages and their constitutent

--- a/man/DSL.Rd
+++ b/man/DSL.Rd
@@ -41,7 +41,7 @@ Passed to \code{rcmdcheck::rcmdcheck()}, default:
 \code{c("--no-manual", "--as-cran")}.}
 
 \item{build_args}{\code{[character]}\cr
-Passed to \code{[rcmdcheck::rcmdcheck()]}, default:
+Passed to \code{rcmdcheck::rcmdcheck()}, default:
 \code{"--force"}.}
 
 \item{error_on}{\code{[character]}\cr
@@ -53,11 +53,11 @@ generate errors as well. If "note", then any check failure generated an
 error.}
 
 \item{repos}{\code{[character]}\cr
-Passed to \code{[rcmdcheck::rcmdcheck()]}, default:
+Passed to \code{rcmdcheck::rcmdcheck()}, default:
 \code{getOption("repos")}.}
 
 \item{timeout}{\code{[numeric]}\cr
-Passed to \code{[rcmdcheck::rcmdcheck()]}, default:
+Passed to \code{rcmdcheck::rcmdcheck()}, default:
 \code{Inf}.}
 }
 \description{

--- a/man/step_rcmdcheck.Rd
+++ b/man/step_rcmdcheck.Rd
@@ -4,23 +4,34 @@
 \alias{step_rcmdcheck}
 \title{Step: Check a package}
 \usage{
-step_rcmdcheck(warnings_are_errors = TRUE, notes_are_errors = FALSE,
-  args = c("--no-manual", "--as-cran"), build_args = "--force")
+step_rcmdcheck(args = c("--no-manual", "--as-cran"),
+  build_args = "--force", error_on = "warning",
+  repos = getOption("repos"), timeout = Inf)
 }
 \arguments{
-\item{warnings_are_errors}{\code{[flag]}\cr
-Should warnings be treated as errors? Default: \code{TRUE}.}
-
-\item{notes_are_errors}{\code{[flag]}\cr
-Should notes be treated as errors? Default: \code{FALSE}.}
-
 \item{args}{\code{[character]}\cr
-Passed to \code{[rcmdcheck::rcmdcheck()]}, default:
+Passed to \code{rcmdcheck::rcmdcheck()}, default:
 \code{c("--no-manual", "--as-cran")}.}
 
 \item{build_args}{\code{[character]}\cr
 Passed to \code{[rcmdcheck::rcmdcheck()]}, default:
 \code{"--force"}.}
+
+\item{error_on}{\code{[character]}\cr
+Whether to throw an error on R CMD check failures. Note that the check is
+always completed (unless a timeout happens), and the error is only thrown
+after completion. If "never", then no errors are thrown. If "error", then
+only ERROR failures generate errors. If "warning", then WARNING failures
+generate errors as well. If "note", then any check failure generated an
+error.}
+
+\item{repos}{\code{[character]}\cr
+Passed to \code{[rcmdcheck::rcmdcheck()]}, default:
+\code{getOption("repos")}.}
+
+\item{timeout}{\code{[numeric]}\cr
+Passed to \code{[rcmdcheck::rcmdcheck()]}, default:
+\code{Inf}.}
 }
 \description{
 Check a package using \pkg{rcmdcheck}, which ultimately calls \code{R CMD check}.

--- a/man/step_rcmdcheck.Rd
+++ b/man/step_rcmdcheck.Rd
@@ -14,7 +14,7 @@ Passed to \code{rcmdcheck::rcmdcheck()}, default:
 \code{c("--no-manual", "--as-cran")}.}
 
 \item{build_args}{\code{[character]}\cr
-Passed to \code{[rcmdcheck::rcmdcheck()]}, default:
+Passed to \code{rcmdcheck::rcmdcheck()}, default:
 \code{"--force"}.}
 
 \item{error_on}{\code{[character]}\cr
@@ -26,11 +26,11 @@ generate errors as well. If "note", then any check failure generated an
 error.}
 
 \item{repos}{\code{[character]}\cr
-Passed to \code{[rcmdcheck::rcmdcheck()]}, default:
+Passed to \code{rcmdcheck::rcmdcheck()}, default:
 \code{getOption("repos")}.}
 
 \item{timeout}{\code{[numeric]}\cr
-Passed to \code{[rcmdcheck::rcmdcheck()]}, default:
+Passed to \code{rcmdcheck::rcmdcheck()}, default:
 \code{Inf}.}
 }
 \description{


### PR DESCRIPTION
- replace `warnings_are_errors` and `notes_are_errors` with `error_on`
- add args `timeout` and `repos`
- call `rcmdcheck()` internally with `error_on = "never"` so that we can trigger the message on found warnings and notes
- remote outdated doc about `step_rcmdcheck()` using a dedicated lib for the check