### PR TITLE
Test on osx default image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ env:
 stages:
 - name: test
 - name: full
-  #if: branch = master
+  if: branch = master
 
 #jobs: 5x Linux (1x with deployment), 1x OS X
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ jobs:
     env:
     - BUILD_PKGDOWN=true
   - os: osx
+    osx_image: xcode9.4
     r: release
   - r: 3.4
   - r: 3.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,6 @@ jobs:
     env:
     - BUILD_PKGDOWN=true
   - os: osx
-    osx_image: xcode7.3
     r: release
   - r: 3.4
   - r: 3.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ env:
 stages:
 - name: test
 - name: full
-  if: branch = master
+  #if: branch = master
 
 #jobs: 5x Linux (1x with deployment), 1x OS X
 jobs:
@@ -52,7 +52,6 @@ jobs:
     env:
     - BUILD_PKGDOWN=true
   - os: osx
-    osx_image: xcode9.4
     r: release
   - r: 3.4
   - r: 3.3


### PR DESCRIPTION
Currently the build fails at xcode7.X
Is there a reason not to use the default image?

Using the default image, the build passes: https://travis-ci.org/ropenscilabs/tic/builds/474957231. 

Feel free to close this PR if there is a reason for the old xcode.