### PR TITLE
Improve macros

### DIFF
--- a/R/dsl.R
+++ b/R/dsl.R
@@ -109,10 +109,12 @@ add_code_step <- function(stage, call = NULL, prepare_call = NULL) {
 #' stages:
 #'
 #' @inheritParams step_rcmdcheck
+#' @param codecov `[flag]`\cr Whether to add a step running `covr::codecov(quiet = FALSE)` to macro `do_package_checks()`.`
 #' @rdname DSL
 #' @export
 #' @importFrom magrittr %>%
 do_package_checks <- function(...,
+                              codecov = TRUE,
                               warnings_are_errors = NULL,
                               notes_are_errors = NULL,
                               args = c("--no-manual", "--as-cran"),
@@ -142,10 +144,12 @@ do_package_checks <- function(...,
       )
     )
 
-  #' 1. A call to [covr::codecov()] in the `"after_success"` stage (only for non-interactive CIs)
-  if (!ci_is_interactive()) {
-    get_stage("after_success") %>%
-      add_code_step(covr::codecov(quiet = FALSE))
+  if (isTRUE(codecov)) {
+    #' 1. A call to [covr::codecov()] in the `"after_success"` stage (only for non-interactive CIs)
+    if (!ci_is_interactive()) {
+      get_stage("after_success") %>%
+        add_code_step(covr::codecov(quiet = FALSE))
+    }
   }
 }
 #' @description
@@ -155,7 +159,7 @@ do_package_checks <- function(...,
 #' @inheritParams step_build_pkgdown
 #' @inheritParams step_setup_push_deploy
 #' @inheritParams step_do_push_deploy
-#' @param build_only Build the pkgdown site but do not deploy it. Removes step
+#' @param build_only `[flag]`\cr Build the pkgdown site but do not deploy it. Removes step
 #'   [step_setup_ssh()], [step_setup_push_deploy()] and [step_do_push_deploy()]
 #'   from macro `do_pkgdown`.
 #'

--- a/R/dsl.R
+++ b/R/dsl.R
@@ -155,7 +155,9 @@ do_package_checks <- function(...,
 #' @inheritParams step_build_pkgdown
 #' @inheritParams step_setup_push_deploy
 #' @inheritParams step_do_push_deploy
-#' @param build_only Build the pkgdown site but do not deploy it.
+#' @param build_only Build the pkgdown site but do not deploy it. Removes step
+#'   [step_setup_ssh()], [step_setup_push_deploy()] and [step_do_push_deploy()]
+#'   from macro `do_pkgdown`.
 #'
 #' @rdname DSL
 #' @export

--- a/R/dsl.R
+++ b/R/dsl.R
@@ -176,8 +176,6 @@ do_pkgdown <- function(...,
     add_step(step_install_deps(repos = repos))
 
   if (isTRUE(build_only)) {
-  } else if (!ci_can_push()) {
-    stop("Deployment is not possible because keys are not set. Try setting `id_rsa` using `travis::use_travis_deploy()`.")
   } else {
 
     #' 1. [step_setup_ssh()] in the `"before_deploy"` to setup the upcoming deployment.

--- a/R/steps-ssh.R
+++ b/R/steps-ssh.R
@@ -22,6 +22,10 @@ AddToKnownHosts <- R6Class(
     },
 
     check = function() {
+
+      # check if we have a SSH key to deploy with
+      ci_can_push()
+
       # only if non-interactive and ssh-keyscan is available
       (!ci_is_interactive()) && (Sys.which("ssh-keyscan") != "")
     }

--- a/R/steps-ssh.R
+++ b/R/steps-ssh.R
@@ -24,7 +24,10 @@ AddToKnownHosts <- R6Class(
     check = function() {
 
       # check if we have a SSH key to deploy with
-      ci_can_push()
+      # only deploy on Travis for now
+      if (inherits(ci(), "TravisCI")) {
+        ci_can_push()
+      }
 
       # only if non-interactive and ssh-keyscan is available
       (!ci_is_interactive()) && (Sys.which("ssh-keyscan") != "")

--- a/docs/reference/DSL.html
+++ b/docs/reference/DSL.html
@@ -207,7 +207,7 @@ to the <code>"install"</code>, <code>"before_deploy"</code> and <code>"deploy"</
 
 <span class='fu'>add_code_step</span>(<span class='no'>stage</span>, <span class='kw'>call</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>prepare_call</span> <span class='kw'>=</span> <span class='kw'>NULL</span>)
 
-<span class='fu'>do_package_checks</span>(<span class='no'>...</span>, <span class='kw'>warnings_are_errors</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
+<span class='fu'>do_package_checks</span>(<span class='no'>...</span>, <span class='kw'>codecov</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>, <span class='kw'>warnings_are_errors</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
   <span class='kw'>notes_are_errors</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>args</span> <span class='kw'>=</span> <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/c'>c</a></span>(<span class='st'>"--no-manual"</span>, <span class='st'>"--as-cran"</span>),
   <span class='kw'>build_args</span> <span class='kw'>=</span> <span class='st'>"--force"</span>, <span class='kw'>error_on</span> <span class='kw'>=</span> <span class='st'>"warning"</span>,
   <span class='kw'>repos</span> <span class='kw'>=</span> <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/options'>getOption</a></span>(<span class='st'>"repos"</span>), <span class='kw'>timeout</span> <span class='kw'>=</span> <span class='fl'>Inf</span>)
@@ -250,6 +250,10 @@ An optional arbitrary R expression executed during preparation.</p></td>
     <tr>
       <th>...</th>
       <td><p>Ignored, used to enforce naming of arguments.</p></td>
+    </tr>
+    <tr>
+      <th>codecov</th>
+      <td><p><code>[flag]</code><br /> Whether to add a step running <code><a href='https://www.rdocumentation.org/packages/covr/topics/codecov'>covr::codecov(quiet = FALSE)</a></code> to macro <code>do_package_checks()</code>.`</p></td>
     </tr>
     <tr>
       <th>warnings_are_errors</th>
@@ -297,7 +301,9 @@ Passed to <code><a href='https://www.rdocumentation.org/packages/rcmdcheck/topic
     </tr>
     <tr>
       <th>build_only</th>
-      <td><p>Build the pkgdown site but do not deploy it.</p></td>
+      <td><p><code>[flag]</code><br /> Build the pkgdown site but do not deploy it. Removes step
+<code><a href='step_setup_ssh.html'>step_setup_ssh()</a></code>, <code><a href='step_setup_push_deploy.html'>step_setup_push_deploy()</a></code> and <code><a href='step_do_push_deploy.html'>step_do_push_deploy()</a></code>
+from macro <code>do_pkgdown</code>.</p></td>
     </tr>
     <tr>
       <th>orphan</th>

--- a/docs/reference/base64serialize.html
+++ b/docs/reference/base64serialize.html
@@ -176,7 +176,7 @@ by <code>base64serialize()</code>.</p>
 
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
     <pre class="examples"><div class='input'><span class='no'>serial</span> <span class='kw'>&lt;-</span> <span class='fu'>base64serialize</span>(<span class='fl'>1</span>:<span class='fl'>10</span>)
-<span class='no'>serial</span></div><div class='output co'>#&gt; [1] "eJwdytEJACAMA9GztVYF93P/SUz9eBCO3A0YHo65Jkeqtd+hYpeQISlTVv0eIl4Aww=="</div><div class='input'><span class='fu'>base64unserialize</span>(<span class='no'>serial</span>)</div><div class='output co'>#&gt;  [1]  1  2  3  4  5  6  7  8  9 10</div></pre>
+<span class='no'>serial</span></div><div class='output co'>#&gt; [1] "eJyL4GJgYGBmYGYHkqxAJgNraIibrgWQ8Q6ImYCYkYGFgRNI8yXn5xYkJpfEZ+aVFKcWosmyJCUWp0LFeMHiEPofSCfICgcVBjCw/4BKg9QAAOv2D1I="</div><div class='input'><span class='fu'>base64unserialize</span>(<span class='no'>serial</span>)</div><div class='output co'>#&gt;  [1]  1  2  3  4  5  6  7  8  9 10</div></pre>
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
     <h2>Contents</h2>

--- a/docs/reference/base64serialize.html
+++ b/docs/reference/base64serialize.html
@@ -176,7 +176,7 @@ by <code>base64serialize()</code>.</p>
 
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
     <pre class="examples"><div class='input'><span class='no'>serial</span> <span class='kw'>&lt;-</span> <span class='fu'>base64serialize</span>(<span class='fl'>1</span>:<span class='fl'>10</span>)
-<span class='no'>serial</span></div><div class='output co'>#&gt; [1] "eJyL4GJgYGBmYGYHkqxAJgNraIibrgWQ8Q6ImYCYkYGFgRNI8yXn5xYkJpfEZ+aVFKcWosmyJCUWp0LFeMHiEPofSCfICgcVBjCw/4BKg9QAAOv2D1I="</div><div class='input'><span class='fu'>base64unserialize</span>(<span class='no'>serial</span>)</div><div class='output co'>#&gt;  [1]  1  2  3  4  5  6  7  8  9 10</div></pre>
+<span class='no'>serial</span></div><div class='output co'>#&gt; [1] "eJwdytEJACAMA9GztVYF93P/SUz9eBCO3A0YboG5Jkeqtd+hYpeQISlTVv0eIiYAwg=="</div><div class='input'><span class='fu'>base64unserialize</span>(<span class='no'>serial</span>)</div><div class='output co'>#&gt;  [1]  1  2  3  4  5  6  7  8  9 10</div></pre>
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
     <h2>Contents</h2>

--- a/man/DSL.Rd
+++ b/man/DSL.Rd
@@ -15,7 +15,7 @@ add_step(stage, step)
 
 add_code_step(stage, call = NULL, prepare_call = NULL)
 
-do_package_checks(..., warnings_are_errors = NULL,
+do_package_checks(..., codecov = TRUE, warnings_are_errors = NULL,
   notes_are_errors = NULL, args = c("--no-manual", "--as-cran"),
   build_args = "--force", error_on = "warning",
   repos = getOption("repos"), timeout = Inf)
@@ -44,6 +44,8 @@ The default is useful if you only pass \code{prepare_call}.}
 An optional arbitrary R expression executed during preparation.}
 
 \item{...}{Ignored, used to enforce naming of arguments.}
+
+\item{codecov}{\code{[flag]}\cr Whether to add a step running \code{covr::codecov(quiet = FALSE)} to macro \code{do_package_checks()}.`}
 
 \item{warnings_are_errors}{\code{[flag]}\cr
 Deprecated, use \code{error_on}.}
@@ -75,7 +77,7 @@ Passed to \code{rcmdcheck::rcmdcheck()}, default:
 Passed to \code{rcmdcheck::rcmdcheck()}, default:
 \code{Inf}.}
 
-\item{build_only}{Build the pkgdown site but do not deploy it. Removes step
+\item{build_only}{\code{[flag]}\cr Build the pkgdown site but do not deploy it. Removes step
 \code{\link[=step_setup_ssh]{step_setup_ssh()}}, \code{\link[=step_setup_push_deploy]{step_setup_push_deploy()}} and \code{\link[=step_do_push_deploy]{step_do_push_deploy()}}
 from macro \code{do_pkgdown}.}
 

--- a/man/DSL.Rd
+++ b/man/DSL.Rd
@@ -75,7 +75,9 @@ Passed to \code{rcmdcheck::rcmdcheck()}, default:
 Passed to \code{rcmdcheck::rcmdcheck()}, default:
 \code{Inf}.}
 
-\item{build_only}{Build the pkgdown site but do not deploy it.}
+\item{build_only}{Build the pkgdown site but do not deploy it. Removes step
+\code{\link[=step_setup_ssh]{step_setup_ssh()}}, \code{\link[=step_setup_push_deploy]{step_setup_push_deploy()}} and \code{\link[=step_do_push_deploy]{step_do_push_deploy()}}
+from macro \code{do_pkgdown}.}
 
 \item{orphan}{\code{[flag]}\cr
 Create and force-push an orphan branch consisting of only one commit?


### PR DESCRIPTION
- move `ci_can_push()` to `step_setup_ssh()` 

- improve doc of `build_only` arg in DSL

- `add `codecov` flag to `do_package_checks()`

- only deploy on Travis (as we cannot set SSH keys on appveyor automatically. This also solves the problem of double deployment in case macros are running on both TravisCI + Appveyor. This behaviour still needs to be documented.