### PR TITLE
improve detect_repo_type()

### DIFF
--- a/R/use_tic.R
+++ b/R/use_tic.R
@@ -109,13 +109,19 @@ use_github_interactive <- function() {
   usethis::use_github()
 }
 
-
 detect_repo_type <- function() {
   if (file.exists("_bookdown.yml")) return("bookdown")
   if (file.exists("_site.yml")) return("site")
   if (file.exists("config.toml")) return("blogdown")
   if (file.exists("DESCRIPTION")) return("package")
-  "unknown"
+
+  cli::cat_bullet("Unable to guess the repo type. Please choose the desired one from the menu.",
+    bullet = "warning")
+
+  switch(menu(c("Blogdown", "Bookdown", "Package", "Website", "Other")) + 1,
+    cat("Nothing done.\n"), return("blogdown"), return("bookdown"),
+    return("package"), return("site"), return("unknown"))
+
 }
 
 yesno <- function(...) {

--- a/R/use_tic.R
+++ b/R/use_tic.R
@@ -115,13 +115,22 @@ detect_repo_type <- function() {
   if (file.exists("config.toml")) return("blogdown")
   if (file.exists("DESCRIPTION")) return("package")
 
+  if (!interactive()) return("unknown")
+
   cli::cat_bullet("Unable to guess the repo type. Please choose the desired one from the menu.",
     bullet = "warning")
 
-  switch(menu(c("Blogdown", "Bookdown", "Package", "Website", "Other")) + 1,
-    cat("Nothing done.\n"), return("blogdown"), return("bookdown"),
-    return("package"), return("site"), return("unknown"))
-
+  choices <- c(
+    blogdown = "Blogdown", bookdown = "Bookdown",
+    package = "Package", website = "Website",
+    unknown = "Other"
+  )
+  chosen <- menu(choices)
+  if (chosen == 0) {
+    stopc("Aborted.")
+  } else {
+    names(choices)[[chosen]]
+  }
 }
 
 yesno <- function(...) {


### PR DESCRIPTION
Spins up an interactive menu if the repo type cannot be guessed by file type heuristics.
Useful when setting up a completely new project without any existing structure.

fixes #161 