### PR TITLE
isTRUE(travis::uses_github()) always FALSE on R < 3.5

### DIFF
--- a/R/use_tic.R
+++ b/R/use_tic.R
@@ -64,7 +64,7 @@ use_tic <- function(quiet = FALSE) {
   )
 
   use_github_interactive()
-  if (!isTRUE(travis::uses_github())) {
+  if (!isTRUE(travis::uses_github()[1])) {
     stopc(
       "A GitHub repository is needed. ",
       "Please create one manually or re-run `use_tic()` to do it automatically."


### PR DESCRIPTION
Although the output of travis::uses_github() is of type atomic and logical, when it is TRUE is does not pass test isTRUE because of its attributes, at least on R 3.4.4 with travis 0.2.11.9001. It is said in R base 3.4.4 documentation :
"isTRUE(x) is an abbreviation of identical(TRUE, x), and so is true if and only if x is a length-one logical vector whose only element is TRUE and which has no attributes (not even names)."
thus giving FALSE when there are some attributes, see https://www.r-bloggers.com/working-with-istrue/ for an example.
It is not the case for upper R versions, see 3.5 documentation: https://www.rdocumentation.org/packages/base/versions/3.5.0/topics/Logic