### PR TITLE
Update packages installed during "prepare" step

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -4,6 +4,7 @@
 verify_install <- function(...) {
   pkg_names <- c(...)
   lapply(pkg_names, verify_install_one)
+  lapply(pkg_names, verify_update_one)
 }
 
 verify_install_one <- function(pkg_name) {
@@ -15,6 +16,10 @@ verify_install_one <- function(pkg_name) {
       )
     }
   }
+}
+
+verify_update_one <- function(pkg_name) {
+  update.packages(pkg_name)
 }
 
 package_installed <- function(pkg_name) {


### PR DESCRIPTION
fixes #184 

- looping over new fun `verify_update_one()` which simply calls `update.packages(<pkg>)`