### PR TITLE
Update support for Circle CI deployment

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,6 +54,7 @@ Suggests:
     base64enc,
     bookdown,
     callr,
+    circle,
     covr,
     devtools,
     drat,
@@ -70,6 +71,7 @@ VignetteBuilder:
   knitr
 Remotes: 
     ropenscilabs/travis
+    pat-s/circle
 ByteCompile: No
 Encoding: UTF-8
 LazyData: TRUE

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -70,7 +70,7 @@ Suggests:
 VignetteBuilder:
   knitr
 Remotes: 
-    ropenscilabs/travis
+    ropenscilabs/travis,
     pat-s/circle
 ByteCompile: No
 Encoding: UTF-8

--- a/R/circleci.R
+++ b/R/circleci.R
@@ -26,7 +26,7 @@ CircleCI <- R6Class(
     get_commit = function() {
       Sys.getenv("TRAVIS_COMMIT")
     },
-    can_push = function() {
+    can_push = function(name) {
       circle::has_checkout_key()
     },
     get_env = function(env) {

--- a/R/circleci.R
+++ b/R/circleci.R
@@ -27,8 +27,10 @@ CircleCI <- R6Class(
       Sys.getenv("TRAVIS_COMMIT")
     },
     can_push = function(name) {
-      if (!requireNamespace("circle")) remotes::install_github("pat-s/circle")
-      circle::has_checkout_key()
+      # FIXME: Currently there is no way to check for the 'github-user-key' on
+      # Circle CI in an easy way (we always need the API key).
+      # Proceed anwyway and error during git push in `step_do_push_deploy()`.
+      TRUE
     },
     get_env = function(env) {
       Sys.getenv(env)

--- a/R/circleci.R
+++ b/R/circleci.R
@@ -27,6 +27,7 @@ CircleCI <- R6Class(
       Sys.getenv("TRAVIS_COMMIT")
     },
     can_push = function(name) {
+      if (!requireNamespace("circle")) remotes::install_github("pat-s/circle")
       circle::has_checkout_key()
     },
     get_env = function(env) {

--- a/R/circleci.R
+++ b/R/circleci.R
@@ -29,7 +29,7 @@ CircleCI <- R6Class(
     can_push = function(name) {
       # FIXME: Currently there is no way to check for the 'github-user-key' on
       # Circle CI in an easy way (we always need the API key).
-      # Proceed anwyway and error during git push in `step_do_push_deploy()`.
+      # Proceed anyway and error during git push in `step_do_push_deploy()`.
       TRUE
     },
     get_env = function(env) {

--- a/R/circleci.R
+++ b/R/circleci.R
@@ -26,8 +26,8 @@ CircleCI <- R6Class(
     get_commit = function() {
       Sys.getenv("TRAVIS_COMMIT")
     },
-    can_push = function(name = "id_rsa") {
-      self$has_env(name)
+    can_push = function() {
+      circle::has_checkout_key()
     },
     get_env = function(env) {
       Sys.getenv(env)

--- a/R/macro-pkgdown.R
+++ b/R/macro-pkgdown.R
@@ -71,7 +71,8 @@ do_pkgdown <- function(...,
     #' 1. [step_setup_push_deploy()] in the `"before_deploy"` stage
     #'    (if `deploy` is set),
     get_stage("before_deploy") %>%
-      add_step(step_setup_ssh()) %>%
+      # step_setup_ssh only needed on Travis CI
+      { ifelse(ci_on_travis() , add_step(step_setup_ssh()), . ) } %>%
       add_step(step_setup_push_deploy(
         path = !!enquo(path),
         branch = !!enquo(branch),

--- a/R/macro-pkgdown.R
+++ b/R/macro-pkgdown.R
@@ -67,12 +67,21 @@ do_pkgdown <- function(...,
 
   if (isTRUE(deploy)) {
     #' 1. [step_setup_ssh()] in the `"before_deploy"` to setup
-    #'    the upcoming deployment (if `deploy` is set),
+    #'    the upcoming deployment (if `deploy` is set and only on Travis CI),
     #' 1. [step_setup_push_deploy()] in the `"before_deploy"` stage
     #'    (if `deploy` is set),
+    if (ci_on_travis()) {
+      get_stage("before_deploy") %>%
+        add_step(step_setup_ssh()) %>%
+        add_step(step_setup_push_deploy(
+          path = !!enquo(path),
+          branch = !!enquo(branch),
+          remote_url = !!enquo(remote_url),
+          orphan = !!enquo(orphan),
+          checkout = !!enquo(checkout)
+        ))
+    } else {
     get_stage("before_deploy") %>%
-      # step_setup_ssh only needed on Travis CI
-      { ifelse(ci_on_travis() , add_step(step_setup_ssh()), . ) } %>%
       add_step(step_setup_push_deploy(
         path = !!enquo(path),
         branch = !!enquo(branch),
@@ -80,6 +89,7 @@ do_pkgdown <- function(...,
         orphan = !!enquo(orphan),
         checkout = !!enquo(checkout)
       ))
+    }
   }
 
   #' 1. [step_build_pkgdown()] in the `"deploy"` stage,

--- a/man/do_pkgdown.Rd
+++ b/man/do_pkgdown.Rd
@@ -61,7 +61,7 @@ to the \code{"install"}, \code{"before_deploy"} and \code{"deploy"} stages:
 \item \code{\link[=step_install_deps]{step_install_deps()}} in the \code{"install"} stage, using the
 \code{repos} argument.
 \item \code{\link[=step_setup_ssh]{step_setup_ssh()}} in the \code{"before_deploy"} to setup
-the upcoming deployment (if \code{deploy} is set),
+the upcoming deployment (if \code{deploy} is set and only on Travis CI),
 \item \code{\link[=step_setup_push_deploy]{step_setup_push_deploy()}} in the \code{"before_deploy"} stage
 (if \code{deploy} is set),
 \item \code{\link[=step_build_pkgdown]{step_build_pkgdown()}} in the \code{"deploy"} stage,


### PR DESCRIPTION
This is a hotfix for Circle CI deployment.

I found that we do not need the whole "SSH" approach on Circle as we can deploy by having a "github user key" set in the "checkout keys" section on circle.
This means 

- no need for setting `id_rsa: true` in the Circle YAML
- no need for `step_setup_ssh()` when using Circle CI for deployments

There is no easy way to check if deploy permissions are sufficient on Circle CI **during the build** because we would need to have the Circle API token set in the build.
(Locally, `circle::use_circle_deploy()` checks this to avoid adding redundant keys.)

Therefore we just proceed in the `ci_can_push()` condition and fail during the `step_do_push_deploy()` step when running `git push`.

The `ifelse()` condition in `macro_pkgdown.R` can be simplified but using a conditional pipe approach threw some weird error. So I went with the old-school approach for now.

Also I added the _circle_ pkg to suggests.