### PR TITLE
- Skip `TicStep$prepare` if `prepare_call` is given in `add_code_s…

### DIFF
--- a/R/steps-base.R
+++ b/R/steps-base.R
@@ -23,12 +23,16 @@ TicStep <- R6Class(
     },
 
     prepare = function() {
-      #' \item{`prepare`}{
-      #'   This method is called when preparing the stage
-      #'   to which a step has been added.
-      #'   Override this method to install any R packages your step might need,
-      #'   because this allows them to be cached for subsequential runs.
-      #' }
+      #' \item{`prepare`}{ This method is called when preparing the stage to
+      #' which a step has been added. It auto-install all packages which are
+      #' needed for a certain step. For example, `step_build_pkgdown()` requires
+      #' the _pkgdown_ package.
+      #'
+      #' For `add_code_step()`, it autodetects any package calls in the form of
+      #' `pkg::fun` and tries to install these packages from CRAN. If a steps
+      #' `prepare_call` is not empty, the `$prepare` method is skipped for this
+      #' step. This can be useful if a package should be installed from
+      #' non-standard repositories, e.g. from Github. }
     },
 
     check = function() {

--- a/R/steps-code.R
+++ b/R/steps-code.R
@@ -15,15 +15,15 @@ RunCode <- R6Class(
     },
 
     prepare = function() {
-      # Needs to happen before auto-detection of package to be installed,
-      # to allow installation of packages from nonstandard repositories
+      # allow installation of packages from nonstandard repositories, e.g.
+      # Github packages using a repo slug
       if (!is.null(private$prepare_call)) {
         private$install_call_dep(private$prepare_call)
         set.seed(private$seed)
         eval(private$prepare_call, envir = .GlobalEnv)
+      } else {
+        private$install_call_dep(private$call)
       }
-
-      private$install_call_dep(private$call)
     }
   ),
 

--- a/man/TicStep.Rd
+++ b/man/TicStep.Rd
@@ -13,12 +13,16 @@ Override this class to create a new step.
 This method must be overridden, it is called when running the stage
 to which a step has been added.
 }
-\item{\code{prepare}}{
-This method is called when preparing the stage
-to which a step has been added.
-Override this method to install any R packages your step might need,
-because this allows them to be cached for subsequential runs.
-}
+\item{\code{prepare}}{ This method is called when preparing the stage to
+which a step has been added. It auto-install all packages which are
+needed for a certain step. For example, \code{step_build_pkgdown()} requires
+the \emph{pkgdown} package.
+
+For \code{add_code_step()}, it autodetects any package calls in the form of
+\code{pkg::fun} and tries to install these packages from CRAN. If a steps
+\code{prepare_call} is not empty, the \verb{$prepare} method is skipped for this
+step. This can be useful if a package should be installed from
+non-standard repositories, e.g. from Github. }
 \item{\code{check}}{
 This method determines if a step is prepared and run.
 Return \code{FALSE} if conditions for running this step are not met.


### PR DESCRIPTION
fixes #205 

Currently, `prepare_call` is executed but afterwards the auto-detection if `TicStep$prepare` is still trying to install the package (from CRAN).

This fails if the package is not available on CRAN. Example: https://travis-ci.org/ropenscilabs/tic.covrpage/builds/633293877#L5376

`tic.R` of linked build:

https://github.com/ropenscilabs/tic.covrpage/blob/0aa2697f54adf1e04682d208345c02114f2a4dd2/tic.R#L18-L25

To fix this, we skip the `TicStep$prepare` call if `prepare_call` != NULL.

In addition, I updated the doc of `TicStep$prepare`.